### PR TITLE
Constrained type for set! of settable

### DIFF
--- a/src/itertools.jl
+++ b/src/itertools.jl
@@ -17,7 +17,7 @@ mutable struct Settable{T}
     v::T
 end
 
-set!(b::Settable{T}, v) where T = (b.v = v)
+set!(b::Settable{T}, v::T) where T = (b.v = v)
 
 Base.IteratorSize(::Type{<:Settable}) = Base.IsInfinite()
 


### PR DESCRIPTION
More nitpicking than anything but here you would allow passing a non T and it would fail in probably a more obscure way than getting something like

```
ERROR: MethodError: no method matching set!(::Settable{Float64}, ::Int64)
```